### PR TITLE
Tiny fix on the class of a badge

### DIFF
--- a/cmd/dmarc-report-converter/consts.go
+++ b/cmd/dmarc-report-converter/consts.go
@@ -70,7 +70,7 @@ table.table.bottomless
             </div>
             <div class="col">
                 <canvas id="stats-chart"></canvas>
-                <center><span class="badge bg-success">passed {{ .Report.MessagesStats.Passed }}</span> <span class="badge bg-danger">failed {{ .Report.MessagesStats.Failed }}</span> <span class="badge">total {{ .Report.MessagesStats.All }}</span></center>
+                <center><span class="badge bg-success">passed {{ .Report.MessagesStats.Passed }}</span> <span class="badge bg-danger">failed {{ .Report.MessagesStats.Failed }}</span> <span class="badge text-bg-light">total {{ .Report.MessagesStats.All }}</span></center>
             </div>
         </div>
         <p></p>
@@ -217,7 +217,7 @@ table.table.bottomless
                 </div>
             </div>
             <div class="col-md-auto">
-                <span class="badge bg-success">passed {{ .Report.MessagesStats.Passed }}</span> <span class="badge bg-danger">failed {{ .Report.MessagesStats.Failed }}</span> <span class="badge">total {{ .Report.MessagesStats.All }}</span>
+                <span class="badge bg-success">passed {{ .Report.MessagesStats.Passed }}</span> <span class="badge bg-danger">failed {{ .Report.MessagesStats.Failed }}</span> <span class="badge text-bg-light">total {{ .Report.MessagesStats.All }}</span>
             </div>
         </div>
         <p></p>


### PR DESCRIPTION
Hello,
after the update to bootstrap 5.2, PR #27, it becomes necessary to add a class in the **total** badge.
Otherwise the color of the text is the same as the background.

![before](https://user-images.githubusercontent.com/3239064/188442666-e3d9ed88-378a-4b23-bf6e-36fa613dbf55.png)
After my edit:
![after](https://user-images.githubusercontent.com/3239064/188445423-fc4dca05-6d9b-4ecd-90e2-5daff6935c84.png)
