### PR TITLE
Print error message when trying to save in a non-writable directory

### DIFF
--- a/cmd/dmarc-report-converter/output.go
+++ b/cmd/dmarc-report-converter/output.go
@@ -38,6 +38,7 @@ func (o *output) do(d dmarc.Report) error {
 		dir := filepath.Dir(file)
 		err = os.MkdirAll(dir, 0755)
 		if err != nil {
+			log.Printf("[ERROR] mkdir: %v, skip", err)
 			return nil
 		}
 

--- a/cmd/dmarc-report-converter/output.go
+++ b/cmd/dmarc-report-converter/output.go
@@ -38,8 +38,7 @@ func (o *output) do(d dmarc.Report) error {
 		dir := filepath.Dir(file)
 		err = os.MkdirAll(dir, 0755)
 		if err != nil {
-			log.Printf("[ERROR] mkdir: %v, skip", err)
-			return nil
+			return err
 		}
 
 		log.Printf("[INFO] output: write to file %v", file)


### PR DESCRIPTION
Currently, dmarc-report-converter silenty fails when trying to write to a directory where it is not allowed to write to.