### PR TITLE
Add support for StartTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ Copy config/config.dist.yaml to config.yaml and change parameters:
 
   * **debug** (bool): print debug messages during IMAP session?
   
-  * **security** (str): select encryption among "tls" (default), "starttls" or "plaintext"
-
+  * **security** (str): select encryption between "tls" (default), "starttls" or "plaintext"
 
 **output** section:
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Copy config/config.dist.yaml to config.yaml and change parameters:
   * **delete** (bool): delete email messages from IMAP server if reports are fetched successfully
 
   * **debug** (bool): print debug messages during IMAP session?
+  
+  * **security** (str): select encryption among "tls" (default), "starttls" or "plaintext"
+
 
 **output** section:
 

--- a/cmd/dmarc-report-converter/config.go
+++ b/cmd/dmarc-report-converter/config.go
@@ -33,6 +33,7 @@ type IMAP struct {
 	Mailbox  string `yaml:"mailbox"`
 	Debug    bool   `yaml:"debug"`
 	Delete   bool   `yaml:"delete"`
+	Security string `yaml:"security"`
 }
 
 // IsConfigured return true if IMAP is configured

--- a/cmd/dmarc-report-converter/imap.go
+++ b/cmd/dmarc-report-converter/imap.go
@@ -20,6 +20,7 @@ func fetchIMAPAttachments(cfg *config) error {
 	var c *client.Client
         var err error
         if cfg.Input.IMAP.Security == "plaintext" {
+		log.Printf("[WARN] Without encryption your credentials may be stolen. Be careful!")
                 c, err = client.Dial(cfg.Input.IMAP.Server)
         } else if cfg.Input.IMAP.Security == "starttls" {
                 // go-imap v2 will replace all the following lines with

--- a/cmd/dmarc-report-converter/imap.go
+++ b/cmd/dmarc-report-converter/imap.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -16,7 +17,31 @@ func fetchIMAPAttachments(cfg *config) error {
 	log.Printf("[INFO] imap: connecting to server %v", cfg.Input.IMAP.Server)
 
 	// connect to server
-	c, err := client.DialTLS(cfg.Input.IMAP.Server, nil)
+	var c *client.Client
+        var err error
+        if cfg.Input.IMAP.Security == "plaintext" {
+                c, err = client.Dial(cfg.Input.IMAP.Server)
+        } else if cfg.Input.IMAP.Security == "starttls" {
+                // go-imap v2 will replace all the following lines with
+                // c, err = client.DialStartTLS(cfg.Input.IMAP.Server, nil)
+		// and there will be no need to import "errors"
+                c, err = client.Dial(cfg.Input.IMAP.Server)
+                if err == nil {
+                        sstRet, sstErr := c.SupportStartTLS();
+                        if sstErr != nil {
+                                err = sstErr
+                        } else if !sstRet {
+                                err = errors.New("server doesn't support starttls")
+                        } else {
+                                err = c.StartTLS(nil);
+                        }
+                }
+                if err != nil {
+                        c.Logout()
+                }
+        } else {
+                c, err = client.DialTLS(cfg.Input.IMAP.Server, nil)
+        }
 	if err != nil {
 		return err
 	}

--- a/config/config.dist.yaml
+++ b/config/config.dist.yaml
@@ -10,6 +10,8 @@ input:
   #  debug: no
   # delete emails from server after fetch?
   #  delete: no
+  # connection security should be: tls (default), starttls, plaintext
+  #  security: "tls"
 
 output:
   # output file


### PR DESCRIPTION
I just discovered your project and I like it very much, but my IMAP server supports only StartTLS.
I didn't want to give up, so I added StartTLS support to it.

Since I was at it I added plaintext support too.
At the last moment I had a bit of regret and I decided to keep it but also to bother the users a little bit with a warning message.

I hope you enjoy my ideas.
Cheers