### PR TITLE
allow for different architectures in tarfile name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NAME       := dmarc-report-converter
 DESTDIR    := /opt
 INSTALLDIR := $(DESTDIR)/dmarc-report-converter
+ARCH       := $(shell arch)
 
 ifeq ($(GITHUB_REF),)
 GIT_VER    := $(shell git describe --abbrev=7 --always --tags)-$(shell git rev-parse --abbrev-ref HEAD)-$(shell date +%Y%m%d)
@@ -43,4 +44,4 @@ $(INSTALLDIR) dist tmp:
 .PHONY: release
 release: clean dist
 	make DESTDIR=./tmp install
-	tar -cvzf dist/$(NAME)_$(GIT_VER)_x86-64.tar.gz --owner=0 --group=0 -C ./tmp $(NAME)
+	tar -cvzf dist/$(NAME)_$(GIT_VER)_$(ARCH).tar.gz --owner=0 --group=0 -C ./tmp $(NAME)


### PR DESCRIPTION
I'm using dmarc-report-converter on an AWS t4g instance which has the aarch64 architecture. (bad choice, I know... haven't rebuilt yet).

when I run "make release" I get a dmarc-report-converter_--20240603_x86-64.tar.gz  file, but the architecture isn't x86_64.

This simple fix allows the tar to have the correct architecture
